### PR TITLE
Add vscode config

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,8 +3,15 @@ vim.g.mapleader = ","
 vim.g.maplocalleader = ","
 
 require("config.lazy")
-require("config.keymaps")
-require("config.options")
-require("config.nvim-tree-config")
-require("config.lsp")
+
+if vim.g.vscode then
+  -- VSCode extension
+  require("config.vscode")
+else
+  -- ordinary Neovim
+  require("config.keymaps")
+  require("config.options")
+  require("config.nvim-tree-config")
+  require("config.lsp")
+end
 

--- a/lua/config/vscode.lua
+++ b/lua/config/vscode.lua
@@ -1,0 +1,22 @@
+local vscode = require('vscode')
+local keymap = vim.keymap.set
+
+local opts = { noremap = true, silent = true }
+
+-- yank to system clipboard
+keymap("v", "y", '"+y', opts)
+-- paste from system clipboard
+keymap({"n", "v"}, "p", '"+p', opts)
+
+-- Visual Block --
+-- Move text up and down
+keymap("x", "J", ":move '>+1<CR>gv-gv", opts)
+keymap("x", "K", ":move '<-2<CR>gv-gv", opts)
+
+-- VS Code specific actions --
+keymap("n", "<leader>n", "<cmd>lua require('vscode').action('workbench.action.toggleSidebarVisibility')<CR>", opts)
+keymap("n", "<leader>r", "<cmd>lua require('vscode').action('editor.action.rename')<CR>", opts)
+keymap("n", "<leader>i", "<cmd>lua require('vscode').action('editor.action.goToDeclaration')<CR>", opts)
+keymap("n", "<leader>b", "<cmd>lua require('vscode').action('workbench.action.navigateBack')<CR>", opts)
+keymap("n", "<leader>d", "<cmd>lua require('vscode').action('extension.debugJest')<CR>", opts)
+


### PR DESCRIPTION
Install [VS Code Neovim](https://github.com/vscode-neovim/vscode-neovim) plugin in VS Code, and add this to user settings for mapping `jj` as `<Esc>` key

```json
    "vscode-neovim.compositeKeys": {
        "jj": {
            "command": "vscode-neovim.escape",
        },
    },
```

Config also reference to [this blog](https://medium.com/@nikmas_dev/vscode-neovim-setup-keyboard-centric-powerful-reliable-clean-and-aesthetic-development-582d34297985)